### PR TITLE
feat: Add support for ignoring specified tables during database conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,22 @@ The above command publishes the configuration file to `config/database-converter
 ```php
 return [
     'chunk_size' => 700,
+    
+    /*
+     * Tables to ignore during conversion.
+     * By default, the 'migrations' table is always ignored.
+     */
+    'ignore_tables' => [
+        // 'table_name_to_ignore',
+        // 'another_table_to_ignore',
+    ],
 ];
 ```
+
+### Configuration Options
+
+- **chunk_size**: The number of records to process in each batch during data conversion. Default is 700.
+- **ignore_tables**: An array of table names to ignore during the conversion process. The `migrations` table is always ignored regardless of this configuration.
 
 ## Usage
 

--- a/config/database-converter-laravel.php
+++ b/config/database-converter-laravel.php
@@ -2,4 +2,13 @@
 
 return [
     'chunk_size' => 700,
+
+    /*
+     * Tables to ignore during conversion.
+     * By default, the 'migrations' table is always ignored.
+     */
+    'ignore_tables' => [
+        // 'table_name_to_ignore',
+        // 'another_table_to_ignore',
+    ],
 ];

--- a/src/DatabaseConverterManager.php
+++ b/src/DatabaseConverterManager.php
@@ -67,6 +67,11 @@ class DatabaseConverterManager
                 return;
             }
 
+            $ignoreTables = config()->array('database-converter-laravel.ignore_tables', []);
+            if (in_array($table, $ignoreTables, true)) {
+                return;
+            }
+
             TableConverter::make($this, $table)
                 ->run();
         });


### PR DESCRIPTION
- Introduced 'ignore_tables' configuration option to specify tables to ignore.
- Updated DatabaseConverterManager to skip ignored tables during conversion.
- Added tests to verify that specified tables and the 'migrations' table are ignored as expected.